### PR TITLE
Add support for fetching logs from Splunk

### DIFF
--- a/docs/logging-support.md
+++ b/docs/logging-support.md
@@ -35,6 +35,12 @@ region = us-east-1
 endpoint_url = https://play.min.io:9000
 ```
 
+## Splunk
+ The following environment variables are required:
+- `SPLUNK_SEARCH_TOKEN`: Token with permission to use search api in splunk.
+- `LOGGING_PLUGIN_API_URL`: The URL of the splunk alongwith port.
+- `LOGGING_PLUGIN_QUERY_PARAMS`: Index needs to be passed as index=name where name is the index name.
+
 ## Common Configuration
 
 These are the common configuration options for all third party logging APIs.

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -44,6 +46,7 @@ import (
 
 const (
 	lokiQueryPath      = "/loki/api/v1/query_range"
+	splunkQueryPath    = "/services/search/v2/jobs"
 	typePipelineRun    = "tekton.dev/v1.PipelineRun"
 	typeTaskRun        = "tekton.dev/v1.TaskRun"
 	typeTaskRunV1Beta1 = "tekton.dev/v1beta1.TaskRun"
@@ -53,8 +56,11 @@ const (
 	defaultBlobPathParams = "/%s/%s/%s/" // parent/result/record
 
 	// TODO make these key configurable in a future release
-	pipelineRunUIDKey = "kubernetes.labels.tekton_dev_pipelineRunUID"
-	taskRunUIDKey     = "kubernetes.labels.tekton_dev_taskRunUID"
+	pipelineRunUIDKey         = "kubernetes.labels.tekton_dev_pipelineRunUID"
+	taskRunUIDKey             = "kubernetes.labels.tekton_dev_taskRunUID"
+	splunkPollInterval        = 5 * time.Second
+	splunkPollTimeoutDuration = 1 * time.Minute
+	splunkTokenEnv            = "SPLUNK_SEARCH_TOKEN"
 )
 
 var (
@@ -458,6 +464,241 @@ func mergeLogParts(logPath []string, re *regexp.Regexp) [][]string {
 	return merged
 }
 
+// getSplunkLogs retrieves logs for a given record from a Splunk backend and writes them to the provided writer.
+//
+// It constructs a Splunk search job using the record's UID and namespace, submits the job, polls for completion, and fetches the resulting logs.
+// The function requires a valid Splunk API URL, a search token from the environment, and an "index" query parameter.
+// Returns an error if any step in the process fails, including job creation, polling, or log retrieval.
+func getSplunkLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) error {
+	URL, err := url.Parse(s.config.LOGGING_PLUGIN_API_URL)
+	if err != nil {
+		s.logger.Error(err)
+		return err
+	}
+	URL.Path = path.Join(URL.Path, splunkQueryPath)
+
+	token := os.Getenv(splunkTokenEnv)
+	if token == "" {
+		s.logger.Error("splunk token not set  SPLUNK_SEARCH_TOKEN")
+		return errors.New("splunk token not set")
+
+	}
+
+	outputFormat := "?output_mode=json"
+
+	var uidKey string
+	switch rec.Type {
+	case typePipelineRun:
+		uidKey = pipelineRunUIDKey
+	case typeTaskRun:
+		uidKey = taskRunUIDKey
+	default:
+		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v, rec Type: %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID, rec.Type)
+		return errors.New("record type is invalid")
+	}
+	index, ok := s.queryParams["index"]
+	if !ok {
+		s.logger.Errorf("index not specified in queryParams: %v\n", s.queryParams)
+		return errors.New("index not specified in query parameters")
+
+	}
+	s.logger.Debugf("splunk request url:%s", URL.String()+outputFormat)
+
+	query := fmt.Sprintf(`search index=%s %s=%q %s=%q | table message %s`,
+		index, uidKey, rec.Name, s.config.LOGGING_PLUGIN_NAMESPACE_KEY, parent,
+		s.config.LOGGING_PLUGIN_CONTAINER_KEY)
+
+	queryData := url.Values{}
+	queryData.Set("search", query)
+
+	req, err := http.NewRequest("POST", URL.String()+outputFormat, bytes.NewReader([]byte(queryData.Encode())))
+	if err != nil {
+		s.logger.Errorf("new request to splunk failed, err: %s:", err.Error())
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.logger.Errorf("request to splunk failed, err: %s, req: %v", err.Error(), req)
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+
+	if resp == nil {
+		s.logger.Errorf("request to splunk failed, received nil response")
+		s.logger.Debugf("splunk request url:%s", URL.String())
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		s.logger.Errorf("Splunk Job Creation API request failed with HTTP status code: %d", resp.StatusCode)
+		return status.Error(codes.Internal, "Error fetching log data - search job creation failed")
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Errorf("failed to read response body, err: %s", err.Error())
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+
+	var searchResponse struct {
+		SID string `json:"sid"`
+	}
+
+	if err := json.Unmarshal(data, &searchResponse); err != nil {
+		s.logger.Errorf("failed to unmarshal Splunk Search response, err: %s, data: %s", err.Error(), string(data))
+		return status.Error(codes.Internal, fmt.Sprintf("Error processing fetched log data, err: %s, data: %s",
+			err.Error(), string(data)))
+	}
+
+	if err := pollSplunkJobStatus(s, URL.String()+"/"+searchResponse.SID+outputFormat, token); err != nil {
+		s.logger.Errorf("failed to poll splunk job status, err: %v", err)
+		return status.Error(codes.Internal, fmt.Sprintf("Error failed to poll splunk search job status, err: %s", err.Error()))
+	}
+
+	req, err = http.NewRequest("GET", URL.String()+"/"+searchResponse.SID+"/results?output_mode=json_rows&count=0", nil)
+	if err != nil {
+		s.logger.Errorf("new request to splunk failed, err: %s:", err.Error())
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	lresp, err := s.client.Do(req)
+	if err != nil {
+		s.logger.Errorf("request to fetch log from  splunk failed, err: %s, req: %v", err.Error(), req)
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+
+	if lresp == nil {
+		s.logger.Errorf("request to splunk failed, received nil response")
+		s.logger.Debugf("splunk request url:%s", URL.String())
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+	defer lresp.Body.Close()
+
+	if lresp.StatusCode != http.StatusOK {
+		s.logger.Errorf("Splunk Fetch Log API request failed with HTTP status code: %d", resp.StatusCode)
+		return status.Error(codes.Internal, "Error fetching log data - fetch log api failed")
+	}
+
+	data, err = io.ReadAll(lresp.Body)
+	if err != nil {
+		s.logger.Errorf("failed to read response body, err: %s", err.Error())
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+
+	var logData struct {
+		Rows [][]string `json:"rows"`
+	}
+	if err := json.Unmarshal(data, &logData); err != nil {
+		s.logger.Errorf("failed to unmarshal Splunk log data, err: %s, data: %s", err.Error(), string(data))
+		return fmt.Errorf("failed to unmarshal Splunk log data, err: %s", err.Error())
+	}
+
+	var logMessages []string
+	for _, msg := range logData.Rows {
+		if len(msg) != 2 {
+			s.logger.Errorf("mismatch in column data, should be 2 received: %v, %v", len(msg), msg)
+			continue
+		}
+		logMessages = append(logMessages, msg[1]+" : "+msg[0])
+	}
+
+	formattedLogs := strings.Join(logMessages, "\n")
+	if _, err = writer.Write([]byte(formattedLogs)); err != nil {
+		s.logger.Errorf("failed to write log data, err: %s", err.Error())
+		return status.Error(codes.Internal, "Error streaming log")
+	}
+
+	return nil
+}
+
+// pollSplunkJobStatus polls the status of a Splunk search job until it is complete, fails, or times out.
+// It sends periodic GET requests to the provided Splunk job status URL using the given token.
+// Returns an error if the job fails, is canceled, or does not complete within the timeout period.
+func pollSplunkJobStatus(s *LogServer, url, token string) error {
+	ticker := time.NewTicker(splunkPollInterval)
+	defer ticker.Stop()
+
+	timeout := time.After(splunkPollTimeoutDuration)
+
+	errSplunkJobFailed := errors.New("splunk job failed")
+
+	for {
+		select {
+		case <-timeout:
+			s.logger.Errorf("waiting for the search job to be done, timeout, url: %v", url)
+			return fmt.Errorf("waiting for the search job to be done, timeout, url: %v", url)
+		case <-ticker.C:
+			err := func() error {
+				req, err := http.NewRequest("GET", url, nil)
+				if err != nil {
+					s.logger.Errorf("new request to splunk failed, err: %s:", err.Error())
+					return fmt.Errorf("new request to splunk failed: err: %s", err.Error())
+				}
+
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := s.client.Do(req)
+				if err != nil {
+					s.logger.Errorf("request to splunk failed, err: %s, req: %v", err.Error(), req)
+					return fmt.Errorf("request to splunk failed, err: %s, req: %v", err.Error(), req)
+				}
+
+				if resp == nil {
+					s.logger.Errorf("request to splunk failed, received nil response,: %s", url)
+					return fmt.Errorf("request to splunk failed, received nil response,: %s", url)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					s.logger.Errorf("Splunk Job Creation API request failed with HTTP status code: %d", resp.StatusCode)
+					return fmt.Errorf("splunk job creation API request failed with HTTP status code: %d", resp.StatusCode)
+				}
+
+				data, err := io.ReadAll(resp.Body)
+				if err != nil {
+					s.logger.Errorf("failed to read response body, err: %s", err.Error())
+					return fmt.Errorf("failed to read response body, err: %s", err.Error())
+				}
+
+				var jobResp struct {
+					Entry []struct {
+						Content struct {
+							DispatchState string `json:"dispatchState"`
+						} `json:"content"`
+					} `json:"entry"`
+				}
+
+				if err := json.Unmarshal(data, &jobResp); err != nil {
+					s.logger.Errorf("failed to unmarshal Splunk Search response, err: %s, data: %s", err.Error(), string(data))
+					return fmt.Errorf("failed to unmarshal Splunk Search response, err: %s, data: %s", err.Error(), string(data))
+				}
+				if len(jobResp.Entry) == 0 {
+					s.logger.Errorf("empty Splunk Search response entry, data: %s", string(data))
+					return fmt.Errorf("empty Splunk Search response entry, data: %s", string(data))
+				}
+
+				switch jobResp.Entry[0].Content.DispatchState {
+				case "DONE":
+					return nil
+				case "INTERNAL_CANCEL", "USER_CANCEL", "BAD_INPUT_CANCEL", "QUIT", "FAILED":
+					return fmt.Errorf("%w: state: %s", errSplunkJobFailed, jobResp.Entry[0].Content.DispatchState)
+				default:
+					return fmt.Errorf("waiting for job to be done: current state %s", jobResp.Entry[0].Content.DispatchState)
+				}
+			}()
+			if err != nil {
+				if errors.Is(err, errSplunkJobFailed) {
+					return err
+				}
+				continue
+			}
+			return nil
+		}
+	}
+}
+
 func (s *LogServer) setLogPlugin() bool {
 	switch strings.ToLower(s.config.LOGS_TYPE) {
 	case string(v1alpha3.LokiLogType):
@@ -466,6 +707,9 @@ func (s *LogServer) setLogPlugin() bool {
 	case string(v1alpha3.BlobLogType):
 		s.IsLogPluginEnabled = true
 		s.getLog = getBlobLogs
+	case string(v1alpha3.SplunkLogType):
+		s.IsLogPluginEnabled = true
+		s.getLog = getSplunkLogs
 	default:
 		// TODO(xinnjie) when s.config.LOGS_TYPE is File also show this error log
 		s.IsLogPluginEnabled = false

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
@@ -251,3 +251,138 @@ func TestMergeLogParts(t *testing.T) {
 	}
 
 }
+
+func TestSplunkLogs(t *testing.T) {
+
+	mockSplunk := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Log the received request for debugging
+		t.Logf("Received request: %s %s", r.Method, r.URL.String())
+		t.Logf("Received headers: %v", r.Header)
+
+		// Verify the request path and query parameters
+		switch r.URL.Path {
+		case "/services/search/v2/jobs":
+			w.WriteHeader(http.StatusCreated)
+			w.Write(json.RawMessage(`{"sid":"1234567"}`))
+			return
+		case "/services/search/v2/jobs/1234567":
+			w.WriteHeader(http.StatusOK)
+			w.Write(json.RawMessage(`{
+    "entry": [
+        {
+            "content": {
+                "dispatchState": "DONE"
+            }
+        }
+    ]
+}`))
+			return
+		case "/services/search/v2/jobs/1234567/results":
+			w.WriteHeader(http.StatusOK)
+			w.Write(json.RawMessage(`{
+    "rows": [
+        [
+            "foo",
+            "step-test"
+        ],
+        [
+            "bar",
+            "step-test"
+        ],
+        [
+            "foo-bar",
+            "step-test"
+        ]
+    ]
+}`))
+		}
+	}))
+	defer mockSplunk.Close()
+
+	os.Setenv("SPLUNK_SEARCH_TOKEN",
+		"eyJraWQiOiJzcGx1bmsuc2VjcmV0IiwiYWxnIjoiSFM1MTIiLCJ2ZXIiOiJ2MiIsInR0eXAiOiJzdGF0aWMifQ.eyJpc3MiOiJzY19hZG1pbiBmcm9tIGZlZG9yYSIsInN1YiI6InNjX2FkbWluIiwiYXVkIjoia3ViZXJuZXRlcyIsImlkcCI6IlNwbHVuayIsImp0aSI6IjI0MGM1MDY3NGJkNDgxYjU5ZWE5MTY5ZDJjN2MyZjM5NDVmZDFhOTM3MWU0Yzg0MTQ0N2NkYTYzYmQ4NmZjMGQiLCJpYXQiOjE3NDYzODA1NDgsImV4cCI6MTc3MjM4OTc1NSwibmJyIjoxNzQ2MzgwNTQ4fQ.WnMJE6Dd0Fmn5AipZtl_bpfwIpfGR6feW63Xs1890XPh1o1CrBTNbslTeIH1b9ewluOfrY7rxToAQMoCO3ZJQA")
+
+	cfg := &config.Config{
+		LOGS_API:                                true,
+		LOGS_TYPE:                               "Splunk",
+		DB_ENABLE_AUTO_MIGRATION:                true,
+		LOGGING_PLUGIN_API_URL:                  mockSplunk.URL,
+		LOGGING_PLUGIN_NAMESPACE_KEY:            "kubernetes.namespace_name",
+		LOGGING_PLUGIN_CONTAINER_KEY:            "kubernetes.container_name",
+		LOGGING_PLUGIN_QUERY_PARAMS:             "index=konflux",
+		LOGGING_PLUGIN_TLS_VERIFICATION_DISABLE: true,
+	}
+
+	srv, err := server.New(cfg, logger.Get("info"), test.NewDB(t))
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	ctx := context.Background()
+	// Create a mock GetLogServer
+	mockServer := &mockGetLogServer{
+		ctx: ctx,
+	}
+
+	res, err := srv.CreateResult(ctx, &pb.CreateResultRequest{
+		Parent: "rh-acs-tenant",
+		Result: &pb.Result{
+			Name: "rh-acs-tenant/results/test-result",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateResult: %v", err)
+	}
+
+	_, err = srv.CreateRecord(ctx, &pb.CreateRecordRequest{
+		Parent: res.GetName(),
+		Record: &pb.Record{
+			Name: record.FormatName(res.GetName(), "25274ae9-d521-4a9c-b254-122c17f64941"),
+			Data: &pb.Any{
+				Type: "tekton.dev/v1.TaskRun",
+				Value: jsonutil.AnyBytes(t, pipelinev1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "25274ae9-d521-4a9c-b254-122c17f64941",
+					},
+					Status: pipelinev1.TaskRunStatus{
+						TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+							StartTime: &metav1.Time{
+								Time: time.Now().Add(-time.Hour),
+							},
+							CompletionTime: &metav1.Time{
+								Time: time.Now(),
+							},
+						},
+					},
+				}),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+
+	// Create a test request
+	req := &pb3.GetLogRequest{
+		Name: log.FormatName(res.GetName(), "25274ae9-d521-4a9c-b254-122c17f64941"),
+	}
+
+	// Call GetLog
+	err = srv.LogPluginServer.GetLog(req, mockServer)
+	t.Logf("recv error: %v", err)
+	if err != nil {
+		t.Fatalf("GetLog returned unexpected error: %v", err)
+	}
+
+	expectedData := "step-test : foo\nstep-test : bar\nstep-test : foo-bar"
+
+	if mockServer.receivedData == nil {
+		t.Fatalf("no data received from GetLog")
+	}
+
+	actualData := mockServer.receivedData.String()
+	if expectedData != actualData {
+		t.Errorf("expected to have received %q, got %q", expectedData, actualData)
+	}
+
+}

--- a/pkg/apis/v1alpha3/types.go
+++ b/pkg/apis/v1alpha3/types.go
@@ -58,6 +58,9 @@ const (
 
 	// BlobLogType defines the log type for logs stored in the Blob - GCS, S3 compatible storage.
 	BlobLogType LogType = "blob"
+
+	// SplunkLogType defines the log type for logs stored in the Splunk.
+	SplunkLogType LogType = "splunk"
 )
 
 // LogStatus defines the current status of the log resource.


### PR DESCRIPTION
This adds support for fetching logs from Splunk. It reuses existing Plugin configuration. User need to supply token in SPLUNK_SEARCH_TOKEN.
Also, LOGGING_PLUGIN_QUERY_PARAMS need to have key value pair of index and index name,

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fetching and displaying logs from Splunk as a new log provider.  
- **Documentation**
  - Updated documentation to include configuration steps and environment variables required for Splunk integration.  
- **Tests**
  - Introduced tests to verify correct retrieval and formatting of logs from Splunk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->